### PR TITLE
HDF 443: Use ETH symbol when displaying UNI pools instead of WETH

### DIFF
--- a/src/halo-hooks/useUniPoolInfo.ts
+++ b/src/halo-hooks/useUniPoolInfo.ts
@@ -84,7 +84,7 @@ export const useUniPoolInfo = (pidLpTokenMap: PoolIdLpTokenMap[]) => {
     }
 
     return { poolsInfo, tokenAddresses }
-  }, [pidLpTokenMap, chainId, library, account])
+  }, [pidLpTokenMap, chainId, library, account, UNI_WETH_ADDRESS])
 
   return fetchPoolInfo
 }

--- a/src/halo-hooks/useUniPoolInfo.ts
+++ b/src/halo-hooks/useUniPoolInfo.ts
@@ -1,5 +1,5 @@
 import { useCallback } from 'react'
-import { Token } from '@sushiswap/sdk'
+import { ChainId, Token, WETH } from '@sushiswap/sdk'
 import { useActiveWeb3React } from 'hooks'
 import { getAddress } from '@ethersproject/address'
 import { PoolInfo, PoolProvider } from './usePoolInfo'
@@ -12,6 +12,8 @@ import { getContract } from 'utils'
 
 export const useUniPoolInfo = (pidLpTokenMap: PoolIdLpTokenMap[]) => {
   const { chainId, library, account } = useActiveWeb3React()
+
+  const UNI_WETH_ADDRESS = WETH[chainId || ChainId.MAINNET].address
 
   const fetchPoolInfo = useCallback(async () => {
     const poolsInfo: PoolInfo[] = []
@@ -29,19 +31,32 @@ export const useUniPoolInfo = (pidLpTokenMap: PoolIdLpTokenMap[]) => {
       const token2Address = getAddress(await PoolContract?.token1())
       const totalReserves = await PoolContract?.getReserves()
 
-      const Token1Contract = getContract(token1Address, ERC20_ABI, library, account ?? undefined)
-      const token1Symbol = await Token1Contract?.symbol()
+      let token1Symbol = ''
+      if (token1Address === UNI_WETH_ADDRESS) {
+        token1Symbol = 'ETH'
+      } else {
+        const Token1Contract = getContract(token1Address, ERC20_ABI, library, account ?? undefined)
+        token1Symbol = await Token1Contract?.symbol()
+      }
 
-      const Token2Contract = getContract(token2Address, ERC20_ABI, library, account ?? undefined)
-      const token2Symbol = await Token2Contract?.symbol()
+      let token2Symbol = ''
+      if (token2Address === UNI_WETH_ADDRESS) {
+        token2Symbol = 'ETH'
+      } else {
+        const Token2Contract = getContract(token2Address, ERC20_ABI, library, account ?? undefined)
+        token2Symbol = await Token2Contract?.symbol()
+      }
 
       const tokenPrice = await getTokensUSDPrice(GetPriceBy.address, [token1Address, token2Address])
+
+      const token1Param = token1Symbol === 'ETH' ? 'ETH' : token1Address
+      const token2Param = token2Symbol === 'ETH' ? 'ETH' : token2Address
 
       poolsInfo.push({
         pid: map.pid,
         pair: `${token1Symbol}/${token2Symbol}`,
         address: getAddress(map.lpToken),
-        addLiquidityUrl: `https://app.uniswap.org/#/add/v2/${token1Address}/${token2Address}`,
+        addLiquidityUrl: `https://app.uniswap.org/#/add/v2/${token1Param}/${token2Param}`,
         liquidity:
           +formatEther(totalReserves[0]) * tokenPrice[token1Address] +
           +formatEther(totalReserves[1]) * tokenPrice[token2Address],


### PR DESCRIPTION
## Description of Changes
- use ETH instead of WETH when displaying UNI pools
- use ETH symbol instead of WETH address when generating add liquidity url for UNI pools

[Link to Jira Ticket](https://halodao.atlassian.net/browse/HDF-443)

To test locally, replace .env with `halodao-interface .env-app.halodao.com` and run `yarn start`

### Developer Checklist:

* [x] I have followed the guidelines in our Contributing document
* [x] This PR has a corresponding JIRA ticket
* [x] My branch conforms with our naming convention i.e. `feature/HDF-XXX-description`
* [x] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [ ] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
