### PR TITLE
Bugfix: fatal error when typing "." or "," on stake amount

### DIFF
--- a/src/components/Farm/FarmPoolCard.tsx
+++ b/src/components/Farm/FarmPoolCard.tsx
@@ -457,7 +457,7 @@ export default function FarmPoolCard({ poolInfo, tokenPrice }: FarmPoolCardProps
 
   // Make use of `useApproveCallback` for checking & setting allowance
   const rewardsContractAddress = chainId ? HALO_REWARDS_ADDRESS[chainId] : undefined
-  const tokenAmount = new TokenAmount(poolInfo.asToken, JSBI.BigInt(parseEther(stakeAmount === '' ? '0' : stakeAmount)))
+  const tokenAmount = new TokenAmount(poolInfo.asToken, JSBI.BigInt(parseEther(`${parseFloat(stakeAmount) || 0}`)))
   const [approveState, approveCallback] = useApproveCallback(tokenAmount, rewardsContractAddress)
 
   // Make use of `useDepositWithdrawPoolTokensCallback` for deposit & withdraw poolTokens methods


### PR DESCRIPTION
## Description of Changes
To fix the issue, stake amount is parsed to float first (or use `0` if `NaN`) before supplying to `JSBI.BigInt()`

[Link to Jira Ticket](https://halodao.atlassian.net/browse/HDF-5)

### Developer Checklist:

* [x] I have followed the guidelines in our Contributing document
* [x] This PR has a corresponding JIRA ticket
* [x] My branch conforms with our naming convention i.e. `feature/HDF-XXX-description`
* [x] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [x] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
