### PR TITLE
Bug fixes/hdb 18 deposit different than quote

### DIFF
--- a/src/components/Tailwind/InputFields/SlippageTolerance.tsx
+++ b/src/components/Tailwind/InputFields/SlippageTolerance.tsx
@@ -40,7 +40,6 @@ const SlippageTolerance = ({ value, didChangeValue }: SlippageToleranceProps) =>
         <QuestionIcon size={16} />
       </div>
       <div className="flex space-x-4 mb-2">
-        <SlippageButton title="0.1%" onClick={() => didChangeValue('0.1')} highlighted={value === '0.1'} />
         <SlippageButton title="0.5%" onClick={() => didChangeValue('0.5')} highlighted={value === '0.5'} />
         <SlippageButton title="1%" onClick={() => didChangeValue('1')} highlighted={value === '1'} />
         <div className="w-20">

--- a/src/components/Tailwind/Layout/PageHeaderLeft.tsx
+++ b/src/components/Tailwind/Layout/PageHeaderLeft.tsx
@@ -15,10 +15,12 @@ const PageHeaderLeft = ({ title, caption, subtitle, link }: PageHeaderLeftProps)
     <div>
       {subtitle && <div className="text-sm font-extrabold tracking-widest uppercase">{subtitle}</div>}
       <div className="text-4xl font-fredoka text-primary mb-4">{title}</div>
-      <div className="mb-1 md:pr-16">{caption}</div>
+      <div className="mb-1">{caption}</div>
       {link && (
         <div className="text-link">
-          <a href={link.url}>{link.text}</a>
+          <a href={link.url} target="_blank" rel="noopener noreferrer">
+            {link.text}
+          </a>
         </div>
       )}
     </div>

--- a/src/components/Tailwind/SegmentControl/SegmentControl.tsx
+++ b/src/components/Tailwind/SegmentControl/SegmentControl.tsx
@@ -3,10 +3,15 @@ import React from 'react'
 interface SegmentControlProps {
   segments: string[]
   activeSegment: number
+  disabledSegments?: number[]
   didChangeSegment: (activeSegment: number) => void
 }
 
-const SegmentControl = ({ segments, activeSegment, didChangeSegment }: SegmentControlProps) => {
+const SegmentControl = ({ segments, activeSegment, disabledSegments, didChangeSegment }: SegmentControlProps) => {
+  const isSegmentDisabled = (segment: number) => {
+    return disabledSegments && disabledSegments.includes(segment)
+  }
+
   return (
     <div className="flex rounded bg-primary-disabled">
       {segments.map((segment, i) => (
@@ -16,11 +21,15 @@ const SegmentControl = ({ segments, activeSegment, didChangeSegment }: SegmentCo
             py-1 px-2 flex-auto
             text-white text-xs text-center font-bold
             rounded
-            cursor-pointer
             transition-all
             ${activeSegment === i ? 'bg-primary' : 'bg-transparent'}
+            ${isSegmentDisabled(i) ? 'cursor-not-allowed' : 'cursor-pointer'}
           `}
-          onClick={() => didChangeSegment(i)}
+          onClick={() => {
+            if (!isSegmentDisabled(i)) {
+              didChangeSegment(i)
+            }
+          }}
         >
           {segment}
         </div>

--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -2,30 +2,22 @@ import { useCallback } from 'react'
 import { useContract } from 'hooks/useContract'
 import CURVE_ABI from 'constants/haloAbis/Curve.json'
 import { BigNumber } from 'ethers'
-import { formatEther, formatUnits, parseEther, parseUnits } from 'ethers/lib/utils'
+import { formatEther, formatUnits, parseEther } from 'ethers/lib/utils'
 import { Token } from '@sushiswap/sdk'
 import { useTransactionAdder } from 'state/transactions/hooks'
-import { useActiveWeb3React } from 'hooks'
-import { AMM_ZAP_ADDRESS } from '../../constants'
-import ZAP_ABI from 'constants/haloAbis/Zap.json'
 
 export const useAddRemoveLiquidity = (address: string, token0: Token, token1: Token) => {
   const CurveContract = useContract(address, CURVE_ABI, true)
   const addTransaction = useTransactionAdder()
 
-  const { chainId } = useActiveWeb3React()
-  const zapAddress = chainId ? AMM_ZAP_ADDRESS[chainId] : undefined
-  const ZapContract = useContract(zapAddress, ZAP_ABI, true)
-
   const viewDeposit = useCallback(
     async (amount: BigNumber) => {
       const res = await CurveContract?.viewDeposit(amount)
-      // console.log('res:', res)
-      console.log('-----------')
-      console.log(`viewDeposit response: (amount: ${amount})`)
-      console.log('lp tokens:', formatEther(res[0]))
-      console.log('token 0:', formatUnits(res[1][0], token0.decimals))
-      console.log('token 1:', formatUnits(res[1][1], token1.decimals))
+      // console.log('-----------')
+      // console.log(`viewDeposit response: (amount: ${amount})`)
+      // console.log('lp tokens:', formatEther(res[0]))
+      // console.log('token 0:', formatUnits(res[1][0], token0.decimals))
+      // console.log('token 1:', formatUnits(res[1][1], token1.decimals))
       return {
         lpToken: formatEther(res[0]),
         base: formatUnits(res[1][0], token0.decimals),
@@ -66,43 +58,49 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
     [CurveContract, token0, token1, addTransaction]
   )
 
+  // const previewDepositGivenQuote = useCallback(
+  //   async (quoteAmount: string, quoteRate: number, quoteWeight: number) => {
+  //     const quoteNumeraire = Number(quoteAmount) * quoteRate
+  //     const totalNumeraire = quoteNumeraire * (1 / quoteWeight)
+  //     const { base, quote } = await viewDeposit(parseEther(`${totalNumeraire}`))
+  //     return {
+  //       deposit: totalNumeraire,
+  //       base,
+  //       quote
+  //     }
+  //   },
+  //   [CurveContract, token0, token1]
+  // )
+
   const previewDepositGivenQuote = useCallback(
-    async (quoteAmount: string, quoteRate: number, baseRate: number) => {
-      // const baseAmount = await ZapContract?.calcMaxBaseForDeposit(address, parseUnits(quoteAmount, token1.decimals))
-      // console.log('calcMaxBaseForDeposit: ', baseAmount.toString())
-
-      // const baseNumeraire = Number(formatUnits(baseAmount, token0.decimals)) * (100 * baseRate)
-      // const quoteNumeraire = Number(quoteAmount) * (100 * quoteRate)
-      // const totalNumeraire = baseNumeraire + quoteNumeraire
-      // console.log('numeraires: ', baseNumeraire, quoteNumeraire, totalNumeraire)
-      // await viewDeposit(parseEther(`${totalNumeraire}`))
-
-      // const depositAmount0 = Number(quoteAmount) * (100 * quoteRate) * 2
-      // await viewDeposit(parseEther(`${depositAmount0}`))
-
-      const depositAmount = Number(quoteAmount) * 2
-      const { base, quote } = await viewDeposit(parseEther(`${depositAmount}`))
+    async (quoteAmount: string) => {
+      const quoteNumeraire = Number(quoteAmount)
+      const totalNumeraire = quoteNumeraire * 2
+      const { lpToken, base, quote } = await viewDeposit(parseEther(`${totalNumeraire}`))
       return {
-        deposit: depositAmount,
+        deposit: totalNumeraire,
+        lpToken,
         base,
         quote
       }
     },
-    [CurveContract, token0, token1]
+    [viewDeposit]
   )
 
   const previewDepositGivenBase = useCallback(
-    async (baseAmount: string, baseRate: number) => {
-      const depositAmount = Number(baseAmount) * (100 * baseRate) * 2
-      const { base, quote } = await viewDeposit(parseEther(`${depositAmount}`))
+    async (baseAmount: string, baseRate: number, baseWeight: number) => {
+      const baseNumeraire = Number(baseAmount) * baseRate
+      const totalNumeraire = baseNumeraire * (1 / baseWeight)
+      const { lpToken, base, quote } = await viewDeposit(parseEther(`${totalNumeraire}`))
       return {
-        deposit: depositAmount,
+        deposit: totalNumeraire,
+        lpToken,
         base,
         quote
       }
     },
-    [CurveContract, token0, token1]
+    [viewDeposit]
   )
 
-  return { viewDeposit, deposit, viewWithdraw, withdraw, previewDepositGivenQuote, previewDepositGivenBase }
+  return { viewDeposit, deposit, viewWithdraw, withdraw, previewDepositGivenBase, previewDepositGivenQuote }
 }

--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -90,7 +90,7 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
   const previewDepositGivenBase = useCallback(
     async (baseAmount: string, baseRate: number, baseWeight: number) => {
       const baseNumeraire = Number(baseAmount) * baseRate
-      const totalNumeraire = baseNumeraire * (1 / baseWeight)
+      const totalNumeraire = baseNumeraire * (baseWeight > 0 ? 1 / baseWeight : 2)
       const { lpToken, base, quote } = await viewDeposit(parseEther(`${totalNumeraire}`))
       return {
         deposit: totalNumeraire,

--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -2,13 +2,20 @@ import { useCallback } from 'react'
 import { useContract } from 'hooks/useContract'
 import CURVE_ABI from 'constants/haloAbis/Curve.json'
 import { BigNumber } from 'ethers'
-import { formatEther, formatUnits, parseEther } from 'ethers/lib/utils'
+import { formatEther, formatUnits, parseEther, parseUnits } from 'ethers/lib/utils'
 import { Token } from '@sushiswap/sdk'
 import { useTransactionAdder } from 'state/transactions/hooks'
+import { useActiveWeb3React } from 'hooks'
+import { AMM_ZAP_ADDRESS } from '../../constants'
+import ZAP_ABI from 'constants/haloAbis/Zap.json'
 
 export const useAddRemoveLiquidity = (address: string, token0: Token, token1: Token) => {
   const CurveContract = useContract(address, CURVE_ABI, true)
   const addTransaction = useTransactionAdder()
+
+  const { chainId } = useActiveWeb3React()
+  const zapAddress = chainId ? AMM_ZAP_ADDRESS[chainId] : undefined
+  const ZapContract = useContract(zapAddress, ZAP_ABI, true)
 
   const viewDeposit = useCallback(
     async (amount: BigNumber) => {
@@ -19,6 +26,11 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
       console.log('lp tokens:', formatEther(res[0]))
       console.log('token 0:', formatUnits(res[1][0], token0.decimals))
       console.log('token 1:', formatUnits(res[1][1], token1.decimals))
+      return {
+        lpToken: formatEther(res[0]),
+        base: formatUnits(res[1][0], token0.decimals),
+        quote: formatUnits(res[1][1], token1.decimals)
+      }
     },
     [CurveContract, token0, token1]
   )
@@ -54,5 +66,43 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
     [CurveContract, token0, token1, addTransaction]
   )
 
-  return { viewDeposit, deposit, viewWithdraw, withdraw }
+  const previewDepositGivenQuote = useCallback(
+    async (quoteAmount: string, quoteRate: number, baseRate: number) => {
+      // const baseAmount = await ZapContract?.calcMaxBaseForDeposit(address, parseUnits(quoteAmount, token1.decimals))
+      // console.log('calcMaxBaseForDeposit: ', baseAmount.toString())
+
+      // const baseNumeraire = Number(formatUnits(baseAmount, token0.decimals)) * (100 * baseRate)
+      // const quoteNumeraire = Number(quoteAmount) * (100 * quoteRate)
+      // const totalNumeraire = baseNumeraire + quoteNumeraire
+      // console.log('numeraires: ', baseNumeraire, quoteNumeraire, totalNumeraire)
+      // await viewDeposit(parseEther(`${totalNumeraire}`))
+
+      // const depositAmount0 = Number(quoteAmount) * (100 * quoteRate) * 2
+      // await viewDeposit(parseEther(`${depositAmount0}`))
+
+      const depositAmount = Number(quoteAmount) * 2
+      const { base, quote } = await viewDeposit(parseEther(`${depositAmount}`))
+      return {
+        deposit: depositAmount,
+        base,
+        quote
+      }
+    },
+    [CurveContract, token0, token1]
+  )
+
+  const previewDepositGivenBase = useCallback(
+    async (baseAmount: string, baseRate: number) => {
+      const depositAmount = Number(baseAmount) * (100 * baseRate) * 2
+      const { base, quote } = await viewDeposit(parseEther(`${depositAmount}`))
+      return {
+        deposit: depositAmount,
+        base,
+        quote
+      }
+    },
+    [CurveContract, token0, token1]
+  )
+
+  return { viewDeposit, deposit, viewWithdraw, withdraw, previewDepositGivenQuote, previewDepositGivenBase }
 }

--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -2,13 +2,24 @@ import { useCallback } from 'react'
 import { useContract } from 'hooks/useContract'
 import CURVE_ABI from 'constants/haloAbis/Curve.json'
 import { BigNumber } from 'ethers'
-import { formatUnits } from 'ethers/lib/utils'
+import { formatEther, formatUnits, parseEther } from 'ethers/lib/utils'
 import { Token } from '@sushiswap/sdk'
 import { useTransactionAdder } from 'state/transactions/hooks'
 
 export const useAddRemoveLiquidity = (address: string, token0: Token, token1: Token) => {
   const CurveContract = useContract(address, CURVE_ABI, true)
   const addTransaction = useTransactionAdder()
+
+  const viewDeposit = useCallback(
+    async (amount: BigNumber) => {
+      const res = await CurveContract?.viewDeposit(amount)
+      // console.log('res:', res)
+      console.log('lp tokens:', formatEther(res[0]))
+      console.log('token 0:', formatUnits(res[1][0], token0.decimals))
+      console.log('token 1:', formatUnits(res[1][1], token1.decimals))
+    },
+    [CurveContract, token0, token1]
+  )
 
   const deposit = useCallback(
     async (amount: BigNumber, deadline: number) => {
@@ -41,5 +52,5 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
     [CurveContract, token0, token1, addTransaction]
   )
 
-  return { deposit, viewWithdraw, withdraw }
+  return { viewDeposit, deposit, viewWithdraw, withdraw }
 }

--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -14,6 +14,8 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
     async (amount: BigNumber) => {
       const res = await CurveContract?.viewDeposit(amount)
       // console.log('res:', res)
+      console.log('-----------')
+      console.log(`viewDeposit response: (amount: ${amount})`)
       console.log('lp tokens:', formatEther(res[0]))
       console.log('token 0:', formatUnits(res[1][0], token0.decimals))
       console.log('token 1:', formatUnits(res[1][1], token1.decimals))

--- a/src/halo-hooks/amm/useAssimilator.ts
+++ b/src/halo-hooks/amm/useAssimilator.ts
@@ -1,0 +1,17 @@
+import { useContract } from 'hooks/useContract'
+import ASSIMILATOR_ABI from 'constants/haloAbis/Assimilator.json'
+import { useCallback } from 'react'
+
+export const useAssimilator = (assimilatorAddress: string) => {
+  const AssimilatorContract = useContract(assimilatorAddress, ASSIMILATOR_ABI, true)
+
+  const viewNumeraireAmount = useCallback(
+    async (rawAmount: string) => {
+      const numeraire = await AssimilatorContract?.viewNumeraireAmount(rawAmount)
+      return numeraire
+    },
+    [AssimilatorContract]
+  )
+
+  return { viewNumeraireAmount }
+}

--- a/src/halo-hooks/amm/useLiquidityPool.ts
+++ b/src/halo-hooks/amm/useLiquidityPool.ts
@@ -35,7 +35,7 @@ export const useLiquidityPool = (address: string, pid: number | undefined) => {
   }, [CurveContract, chainId, library])
 
   const getLiquidity = useCallback(async () => {
-    if (!library) return { total: 0, tokens: [0, 0] }
+    if (!library) return { total: 0, tokens: [0, 0], weights: [0, 0], rates: [0, 0] }
 
     const res = await CurveContract?.liquidity()
 
@@ -59,6 +59,7 @@ export const useLiquidityPool = (address: string, pid: number | undefined) => {
 
     const token0Rate = Number(formatEther(rate0.mul(1e8)))
     const token1Rate = Number(formatEther(rate1.mul(1e8)))
+    console.log(`${address} rates:`, token0Rate, token1Rate)
 
     return {
       total: res.total_,

--- a/src/halo-hooks/amm/useLiquidityPool.ts
+++ b/src/halo-hooks/amm/useLiquidityPool.ts
@@ -19,14 +19,20 @@ export const useLiquidityPool = (address: string, pid: number | undefined) => {
   const getTokens = useCallback(async () => {
     if (!chainId || !library) return []
 
-    const token0Address = await CurveContract?.derivatives(0)
-    const token1Address = await CurveContract?.derivatives(1)
+    const [token0Address, token1Address] = await Promise.all([
+      CurveContract?.derivatives(0),
+      CurveContract?.derivatives(1)
+    ])
+
     const Token0Contract = getContract(token0Address, ERC20_ABI, library)
     const Token1Contract = getContract(token1Address, ERC20_ABI, library)
-    const token0Symbol = await Token0Contract?.symbol()
-    const token1Symbol = await Token1Contract?.symbol()
-    const token0Decimals = await Token0Contract?.decimals()
-    const token1Decimals = await Token1Contract?.decimals()
+
+    const [token0Symbol, token1Symbol, token0Decimals, token1Decimals] = await Promise.all([
+      Token0Contract?.symbol(),
+      Token1Contract?.symbol(),
+      Token0Contract?.decimals(),
+      Token1Contract?.decimals()
+    ])
 
     return [
       new Token(chainId, token0Address, token0Decimals, token0Symbol, token0Symbol),
@@ -39,14 +45,20 @@ export const useLiquidityPool = (address: string, pid: number | undefined) => {
 
     const res = await CurveContract?.liquidity()
 
-    const derivatives0 = await CurveContract?.derivatives(0)
-    const derivatives1 = await CurveContract?.derivatives(1)
-    const assimialtor0Address = await CurveContract?.assimilator(derivatives0)
-    const assimialtor1Address = await CurveContract?.assimilator(derivatives1)
+    const [derivatives0, derivatives1] = await Promise.all([
+      CurveContract?.derivatives(0),
+      CurveContract?.derivatives(1)
+    ])
+
+    const [assimialtor0Address, assimialtor1Address] = await Promise.all([
+      CurveContract?.assimilator(derivatives0),
+      CurveContract?.assimilator(derivatives1)
+    ])
+
     const Assimilator0Contract = getContract(assimialtor0Address, ASSIMILATOR_ABI, library)
     const Assimilator1Contract = getContract(assimialtor1Address, ASSIMILATOR_ABI, library)
-    const rate0 = await Assimilator0Contract.getRate()
-    const rate1 = await Assimilator1Contract.getRate()
+
+    const [rate0, rate1] = await Promise.all([Assimilator0Contract.getRate(), Assimilator1Contract.getRate()])
 
     const token0Numeraire = res.individual_[0]
     const token0Value = token0Numeraire.mul(1e8).div(rate0) // based on Assimilator's viewRawAmount()

--- a/src/halo-hooks/amm/useLiquidityPool.ts
+++ b/src/halo-hooks/amm/useLiquidityPool.ts
@@ -1,21 +1,20 @@
 import { useCallback } from 'react'
 import { useActiveWeb3React } from 'hooks'
-import { useContract } from 'hooks/useContract'
+import { useContract, useHALORewardsContract } from 'hooks/useContract'
 import CURVE_ABI from 'constants/haloAbis/Curve.json'
 import ASSIMILATOR_ABI from 'constants/haloAbis/Assimilator.json'
-import REWARDS_ABI from 'constants/haloAbis/Rewards.json'
 import { formatUnits } from 'ethers/lib/utils'
 import { ERC20_ABI } from 'constants/abis/erc20'
 import { getContract } from 'utils'
 import { Token } from '@sushiswap/sdk'
-import { HALO_REWARDS_V1_ADDRESS } from '../../constants'
 import { BigNumber } from 'ethers'
 import Fraction from 'constants/Fraction'
 
 export const useLiquidityPool = (address: string, pid: number | undefined) => {
   const { account, library, chainId } = useActiveWeb3React()
   const CurveContract = useContract(address, CURVE_ABI, true)
-  const RewardsContract = useContract(chainId ? HALO_REWARDS_V1_ADDRESS[chainId] : undefined, REWARDS_ABI, true)
+  const RewardsContract = useHALORewardsContract()
+
   const getTokens = useCallback(async () => {
     if (!chainId || !library) return []
 
@@ -93,14 +92,14 @@ export const useLiquidityPool = (address: string, pid: number | undefined) => {
   }, [CurveContract])
 
   const getStakedLPToken = useCallback(async () => {
-    if (!pid) return BigNumber.from(0)
+    if (pid === undefined) return BigNumber.from(0)
 
     const res = await RewardsContract?.userInfo(pid, account)
     return res.amount
   }, [RewardsContract, account, pid])
 
   const getPendingRewards = useCallback(async () => {
-    if (!pid) return BigNumber.from(0)
+    if (pid === undefined) return BigNumber.from(0)
 
     const res = await RewardsContract?.pendingRewardToken(pid, account)
     return res

--- a/src/halo-hooks/amm/useZap.ts
+++ b/src/halo-hooks/amm/useZap.ts
@@ -126,12 +126,22 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
     [ZapContract, curveAddress, token0, token1, addTransaction]
   )
 
+  const calcMaxBaseForDeposit = useCallback(
+    async (amount: string) => {
+      const quoteAmount = parseUnits(amount, token1.decimals)
+      const res = await ZapContract?.calcMaxBaseForDeposit(curveAddress, quoteAmount)
+      return res
+    },
+    [ZapContract, curveAddress, token0, token1]
+  )
+
   return {
     calcMaxDepositAmountGivenBase,
     calcMaxDepositAmountGivenQuote,
     calcSwapAmountForZapFromBase,
     calcSwapAmountForZapFromQuote,
     zapFromBase,
-    zapFromQuote
+    zapFromQuote,
+    calcMaxBaseForDeposit
   }
 }

--- a/src/halo-hooks/amm/useZap.ts
+++ b/src/halo-hooks/amm/useZap.ts
@@ -22,19 +22,19 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
   const calcMaxDepositAmountGivenBase = useCallback(
     async (amount: string) => {
       const baseAmount = parseUnits(amount, token0.decimals)
-      console.log('calcMaxDepositAmountGivenBase params:', amount, curveAddress, baseAmount.toString())
       const res = await ZapContract?.calcMaxDepositAmountGivenBase(curveAddress, baseAmount)
-      console.log(
-        'calcMaxDepositAmountGivenBase res:',
-        formatEther(res[0]),
-        formatEther(res[1]),
-        formatUnits(res[2][0], token0.decimals),
-        formatUnits(res[2][1], token1.decimals)
-      )
+      // console.log(
+      //   'calcMaxDepositAmountGivenBase res:',
+      //   formatEther(res[0]),
+      //   formatEther(res[1]),
+      //   formatUnits(res[2][0], token0.decimals),
+      //   formatUnits(res[2][1], token1.decimals)
+      // )
 
       return {
         maxDeposit: formatEther(res[0]),
         lpAmount: formatEther(res[1]),
+        baseAmount: formatUnits(res[2][0], token0.decimals),
         quoteAmount: formatUnits(res[2][1], token1.decimals)
       }
     },
@@ -54,20 +54,20 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
   const calcMaxDepositAmountGivenQuote = useCallback(
     async (amount: string) => {
       const quoteAmount = parseUnits(amount, token1.decimals)
-      console.log('calcMaxDepositAmountGivenQuote params:', amount, curveAddress, quoteAmount.toString())
       const res = await ZapContract?.calcMaxDepositAmountGivenQuote(curveAddress, quoteAmount)
-      console.log(
-        'calcMaxDepositAmountGivenQuote res:',
-        formatEther(res[0]),
-        formatEther(res[1]),
-        formatUnits(res[2][0], token0.decimals),
-        formatUnits(res[2][1], token1.decimals)
-      )
+      // console.log(
+      //   'calcMaxDepositAmountGivenQuote res:',
+      //   formatEther(res[0]),
+      //   formatEther(res[1]),
+      //   formatUnits(res[2][0], token0.decimals),
+      //   formatUnits(res[2][1], token1.decimals)
+      // )
 
       return {
         maxDeposit: formatEther(res[0]),
         lpAmount: formatEther(res[1]),
-        baseAmount: formatUnits(res[2][0], token0.decimals)
+        baseAmount: formatUnits(res[2][0], token0.decimals),
+        quoteAmount: formatUnits(res[2][1], token1.decimals)
       }
     },
     [ZapContract, curveAddress, token0, token1]
@@ -79,7 +79,6 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
   const calcSwapAmountForZapFromBase = useCallback(
     async (amount: string) => {
       const baseAmount = parseUnits(amount, token0.decimals)
-      console.log('calcSwapAmountForZapFromBase params:', amount, curveAddress, baseAmount.toString())
       const swapAmount = await ZapContract?.calcSwapAmountForZapFromBase(curveAddress, baseAmount)
       return formatUnits(swapAmount, token0.decimals)
     },
@@ -126,22 +125,12 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
     [ZapContract, curveAddress, token0, token1, addTransaction]
   )
 
-  const calcMaxBaseForDeposit = useCallback(
-    async (amount: string) => {
-      const quoteAmount = parseUnits(amount, token1.decimals)
-      const res = await ZapContract?.calcMaxBaseForDeposit(curveAddress, quoteAmount)
-      return res
-    },
-    [ZapContract, curveAddress, token0, token1]
-  )
-
   return {
     calcMaxDepositAmountGivenBase,
     calcMaxDepositAmountGivenQuote,
     calcSwapAmountForZapFromBase,
     calcSwapAmountForZapFromQuote,
     zapFromBase,
-    zapFromQuote,
-    calcMaxBaseForDeposit
+    zapFromQuote
   }
 }

--- a/src/halo-hooks/amm/useZap.ts
+++ b/src/halo-hooks/amm/useZap.ts
@@ -22,7 +22,15 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
   const calcMaxDepositAmountGivenBase = useCallback(
     async (amount: string) => {
       const baseAmount = parseUnits(amount, token0.decimals)
+      console.log('calcMaxDepositAmountGivenBase params:', amount, curveAddress, baseAmount.toString())
       const res = await ZapContract?.calcMaxDepositAmountGivenBase(curveAddress, baseAmount)
+      console.log(
+        'calcMaxDepositAmountGivenBase res:',
+        formatEther(res[0]),
+        formatEther(res[1]),
+        formatUnits(res[2][0], token0.decimals),
+        formatUnits(res[2][1], token1.decimals)
+      )
 
       return {
         maxDeposit: formatEther(res[0]),
@@ -46,7 +54,15 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
   const calcMaxDepositAmountGivenQuote = useCallback(
     async (amount: string) => {
       const quoteAmount = parseUnits(amount, token1.decimals)
+      console.log('calcMaxDepositAmountGivenQuote params:', amount, curveAddress, quoteAmount.toString())
       const res = await ZapContract?.calcMaxDepositAmountGivenQuote(curveAddress, quoteAmount)
+      console.log(
+        'calcMaxDepositAmountGivenQuote res:',
+        formatEther(res[0]),
+        formatEther(res[1]),
+        formatUnits(res[2][0], token0.decimals),
+        formatUnits(res[2][1], token1.decimals)
+      )
 
       return {
         maxDeposit: formatEther(res[0]),
@@ -63,6 +79,7 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
   const calcSwapAmountForZapFromBase = useCallback(
     async (amount: string) => {
       const baseAmount = parseUnits(amount, token0.decimals)
+      console.log('calcSwapAmountForZapFromBase params:', amount, curveAddress, baseAmount.toString())
       const swapAmount = await ZapContract?.calcSwapAmountForZapFromBase(curveAddress, baseAmount)
       return formatUnits(swapAmount, token0.decimals)
     },

--- a/src/pages/Tailwind/Pool/ExpandablePoolRow.tsx
+++ b/src/pages/Tailwind/Pool/ExpandablePoolRow.tsx
@@ -78,7 +78,13 @@ const ExpandablePoolRow = ({ poolAddress, pid, isExpanded, onClick }: Expandable
     Promise.all(promises)
       .then(results => {
         const tokens: Token[] = results[0]
-        const liquidity: { total: BigNumber; tokens: BigNumber[]; weights: number[]; rates: number[] } = results[1]
+        const liquidity: {
+          total: BigNumber
+          tokens: BigNumber[]
+          weights: number[]
+          rates: number[]
+          assimilators: string[]
+        } = results[1]
         const balance: BigNumber = results[2]
         const staked: BigNumber = results[3]
         const rewards: BigNumber = results[4]
@@ -105,7 +111,8 @@ const ExpandablePoolRow = ({ poolAddress, pid, isExpanded, onClick }: Expandable
           held: Number(formatEther(balance)),
           staked: Number(formatEther(staked)),
           earned: Number(formatEther(rewards)),
-          totalSupply: Number(formatEther(totalSupply))
+          totalSupply: Number(formatEther(totalSupply)),
+          assimilators: liquidity.assimilators
         })
       })
       .catch(e => {

--- a/src/pages/Tailwind/Pool/PoolCardRight.tsx
+++ b/src/pages/Tailwind/Pool/PoolCardRight.tsx
@@ -16,8 +16,8 @@ const PoolCardRight = ({ pool }: PoolCardRightProps) => {
     history.push(`/farm/${pool.address}`)
   }
 
-  const lpToken0Price = pool.weights.token0 * (1 / (pool.rates.token0 * 100))
-  const lpToken1Price = pool.weights.token1 * (1 / (pool.rates.token1 * 100))
+  const lpToken0Price = pool.weights.token0 * (1 / pool.rates.token0)
+  const lpToken1Price = pool.weights.token1 * (1 / pool.rates.token1)
 
   return (
     <div className="p-4 text-white bg-primary-hover rounded-tr-card rounded-tl-card md:rounded-br-card md:rounded-bl-card">

--- a/src/pages/Tailwind/Pool/index.tsx
+++ b/src/pages/Tailwind/Pool/index.tsx
@@ -61,8 +61,8 @@ const Pool = () => {
 
   return (
     <PageWrapper>
-      <div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-16 md:items-center">
-        <div className="md:w-1/2">
+      <div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:items-center">
+        <div className="md:w-1/2 md:pr-16">
           <PageHeaderLeft
             subtitle="Add/Remove Liquidity"
             title="Pools"

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
@@ -17,7 +17,7 @@ const AddLiquidity = ({ pool }: AddLiquidityProps) => {
   const [baseAmount, setBaseAmount] = useState('')
   const [quoteAmount, setQuoteAmount] = useState('')
   const [zapAmount, setZapAmount] = useState('')
-  const [zapFromBase, setZapFromBase] = useState(false)
+  const [isGivenBase, setIsGivenBase] = useState(false)
   const [slippage, setSlippage] = useState('')
 
   const { account } = useActiveWeb3React()
@@ -47,13 +47,14 @@ const AddLiquidity = ({ pool }: AddLiquidityProps) => {
           onBaseAmountChanged={setBaseAmount}
           onQuoteAmountChanged={setQuoteAmount}
           onDeposit={() => setShowModal(true)}
+          onIsGivenBaseChanged={setIsGivenBase}
         />
       ) : (
         <SingleSidedLiquidity
           pool={pool}
           balances={balances}
           onZapAmountChanged={setZapAmount}
-          onZapFromBaseChanged={setZapFromBase}
+          onIsGivenBaseChanged={setIsGivenBase}
           onSlippageChanged={setSlippage}
           onDeposit={() => setShowModal(true)}
         />
@@ -68,7 +69,7 @@ const AddLiquidity = ({ pool }: AddLiquidityProps) => {
         zapAmount={zapAmount}
         slippage={slippage}
         isMultisided={activeSegment === 0}
-        isZappingFromBase={zapFromBase}
+        isGivenBase={isGivenBase}
       />
     </div>
   )

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
@@ -24,6 +24,8 @@ const AddLiquidity = ({ pool }: AddLiquidityProps) => {
   const tokenBalances = useTokenBalances(account ?? undefined, [pool.token0, pool.token1])
   const balances = [tokenBalances[pool.token0.address], tokenBalances[pool.token1.address]]
 
+  const disabledSegments = pool.pooled.total > 0 ? undefined : [1]
+
   return (
     <div>
       <div className="flex items-center justify-end">
@@ -33,6 +35,7 @@ const AddLiquidity = ({ pool }: AddLiquidityProps) => {
         <SegmentControl
           segments={['Two-sided', 'Single-sided']}
           activeSegment={activeSegment}
+          disabledSegments={disabledSegments}
           didChangeSegment={i => setActiveSegment(i)}
         />
       </div>

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
@@ -22,7 +22,7 @@ enum AddLiquityModalState {
 
 interface AddLiquityModalProps {
   isMultisided: boolean
-  isZappingFromBase?: boolean
+  isGivenBase?: boolean
   pool: PoolData
   baseAmount?: string
   quoteAmount?: string
@@ -34,7 +34,7 @@ interface AddLiquityModalProps {
 
 const AddLiquityModal = ({
   isMultisided,
-  isZappingFromBase,
+  isGivenBase,
   pool,
   baseAmount,
   quoteAmount,
@@ -59,12 +59,12 @@ const AddLiquityModal = ({
   const {
     calcSwapAmountForZapFromBase,
     calcSwapAmountForZapFromQuote,
-    calcMaxDepositAmountGivenQuote,
+    calcMaxDepositAmountGivenBase,
     zapFromBase,
     zapFromQuote
   } = useZap(pool.address, pool.token0, pool.token1)
   const { viewOriginSwap, viewTargetSwap } = useSwap(pool)
-  const { deposit } = useAddRemoveLiquidity(pool.address, pool.token0, pool.token1)
+  const { deposit, previewDepositGivenQuote } = useAddRemoveLiquidity(pool.address, pool.token0, pool.token1)
 
   /**
    * Main logic for updating confirm add liquidity UI
@@ -81,7 +81,7 @@ const AddLiquityModal = ({
       baseTokenAmount = Number(baseAmount)
       quoteTokenAmount = Number(quoteAmount)
     } else {
-      if (isZappingFromBase) {
+      if (isGivenBase) {
         const swapAmount = await calcSwapAmountForZapFromBase(zapAmount!) // eslint-disable-line
         quoteTokenAmount = Number(await viewOriginSwap(swapAmount))
         baseTokenAmount = Number(zapAmount) - Number(swapAmount)
@@ -94,19 +94,33 @@ const AddLiquityModal = ({
 
     setTokenAmounts([baseTokenAmount, quoteTokenAmount])
 
-    const { maxDeposit, lpAmount } = await calcMaxDepositAmountGivenQuote(`${quoteTokenAmount}`)
+    let maxDeposit = '0'
+    let lpAmount = '0'
+    let basePrice = 0
+    let quotePrice = 0
+
+    if (isGivenBase) {
+      const res = await calcMaxDepositAmountGivenBase(`${baseTokenAmount}`)
+      maxDeposit = res.maxDeposit
+      lpAmount = res.lpAmount
+      basePrice = Number(res.quoteAmount) / Number(res.baseAmount)
+      quotePrice = Number(res.baseAmount) / Number(res.quoteAmount)
+    } else {
+      const res = await previewDepositGivenQuote(`${quoteTokenAmount}`)
+      maxDeposit = `${res.deposit}`
+      lpAmount = res.lpToken
+      basePrice = Number(res.quote) / Number(res.base)
+      quotePrice = Number(res.base) / Number(res.quote)
+    }
+
     setDepositAmount(maxDeposit)
+    setTokenPrices([basePrice, quotePrice])
 
     const maxLpAmount = Number(lpAmount)
     setLpAmount({
       target: maxLpAmount,
       min: maxLpAmount - maxLpAmount * (slippage !== '' ? Number(slippage) / 100 : 0)
     })
-
-    const basePrice = 1 * (pool.rates.token0 * 100) * (pool.weights.token0 / pool.weights.token1)
-    const quotePrice =
-      (1 * (pool.rates.token1 * 100) * (pool.weights.token1 / pool.weights.token0)) / (pool.rates.token0 * 100)
-    setTokenPrices([basePrice, quotePrice])
 
     setPoolShare(maxLpAmount / (pool.pooled.total + maxLpAmount))
   }
@@ -163,7 +177,7 @@ const AddLiquityModal = ({
     setState(AddLiquityModalState.InProgress)
     try {
       const deadline = getFutureTime()
-      const func = isZappingFromBase ? zapFromBase : zapFromQuote
+      const func = isGivenBase ? zapFromBase : zapFromQuote
       const tx = await func(zapAmount!, deadline, parseEther(`${lpAmount.min}`)) // eslint-disable-line
       setTxHash(tx.hash)
       await tx.wait()

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
@@ -64,7 +64,11 @@ const AddLiquityModal = ({
     zapFromQuote
   } = useZap(pool.address, pool.token0, pool.token1)
   const { viewOriginSwap, viewTargetSwap } = useSwap(pool)
-  const { deposit, previewDepositGivenQuote } = useAddRemoveLiquidity(pool.address, pool.token0, pool.token1)
+  const { deposit, previewDepositGivenBase, previewDepositGivenQuote } = useAddRemoveLiquidity(
+    pool.address,
+    pool.token0,
+    pool.token1
+  )
 
   /**
    * Main logic for updating confirm add liquidity UI
@@ -99,14 +103,19 @@ const AddLiquityModal = ({
     let basePrice = 0
     let quotePrice = 0
 
-    if (isGivenBase) {
+    if (isGivenBase && pool.pooled.total > 0) {
       const res = await calcMaxDepositAmountGivenBase(`${baseTokenAmount}`)
       maxDeposit = res.maxDeposit
       lpAmount = res.lpAmount
       basePrice = Number(res.quoteAmount) / Number(res.baseAmount)
       quotePrice = Number(res.baseAmount) / Number(res.quoteAmount)
     } else {
-      const res = await previewDepositGivenQuote(`${quoteTokenAmount}`)
+      let res: any
+      if (isGivenBase) {
+        res = await previewDepositGivenBase(`${baseTokenAmount}`, pool.rates.token0, pool.weights.token0)
+      } else {
+        res = await previewDepositGivenQuote(`${quoteTokenAmount}`)
+      }
       maxDeposit = `${res.deposit}`
       lpAmount = res.lpToken
       basePrice = Number(res.quote) / Number(res.base)

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquityModal.tsx
@@ -268,11 +268,11 @@ const AddLiquityModal = ({
         <div className="text-center font-bold mb-2">
           Adding{' '}
           <b>
-            {formatNumber(Number(baseAmount))} {pool.token0.symbol}
+            {formatNumber(isMultisided ? Number(baseAmount) : tokenAmounts[0])} {pool.token0.symbol}
           </b>{' '}
           and{' '}
           <b>
-            {formatNumber(Number(quoteAmount))} {pool.token1.symbol}
+            {formatNumber(isMultisided ? Number(quoteAmount) : tokenAmounts[1])} {pool.token1.symbol}
           </b>
         </div>
         <div className="text-center text-sm text-gray-500">Confirm this transaction in your wallet</div>

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -71,6 +71,11 @@ const MultiSidedLiquidity = ({
     }
   }
 
+  useEffect(() => {
+    console.log('-----------')
+    console.log('pool detail: ', pool)
+  }, [])
+
   /**
    * Update base amount upon entering quote amount
    **/
@@ -78,13 +83,22 @@ const MultiSidedLiquidity = ({
     setQuoteInput(val)
     onQuoteAmountChanged(val)
 
+    console.log('-----------')
+    console.log('onQuoteInputUpdate')
+
     if (val !== '') {
-      const { baseAmount } = await calcMaxDepositAmountGivenQuote(val)
+      console.log('ZAP:')
+      const { maxDeposit, baseAmount } = await calcMaxDepositAmountGivenQuote(val)
       setBaseInput(baseAmount)
       onBaseAmountChanged(baseAmount)
 
+      // await viewDeposit(parseEther(maxDeposit))
+
+      console.log('MANUAL:')
       const input1 = Number(val)
-      const input0 = (input1 / pool.rates.token0) * pool.rates.token1 * (pool.weights.token0 / pool.weights.token1)
+      //const input0 = (input1 / pool.rates.token0) * pool.rates.token1 * (pool.weights.token0 / pool.weights.token1)
+      const input0 = (input1 / pool.rates.token0) * pool.rates.token1
+      // base = (100 / 0.0118463) * 0.0100065745 * (0.47734119 / 0.5226588)
       console.log('base calculated value: ', input0)
 
       // const totalNumeraire =

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -39,7 +39,11 @@ const MultiSidedLiquidity = ({
   const [quoteInput, setQuoteInput] = useState('')
 
   const { calcMaxDepositAmountGivenBase } = useZap(pool.address, pool.token0, pool.token1)
-  const { previewDepositGivenQuote } = useAddRemoveLiquidity(pool.address, pool.token0, pool.token1)
+  const { previewDepositGivenBase, previewDepositGivenQuote } = useAddRemoveLiquidity(
+    pool.address,
+    pool.token0,
+    pool.token1
+  )
 
   const baseTokenAmount = new TokenAmount(pool.token0, JSBI.BigInt(parseEther(baseInput !== '' ? baseInput : '0')))
   const [baseApproveState, baseApproveCallback] = useApproveCallback(baseTokenAmount, pool.address)
@@ -57,13 +61,16 @@ const MultiSidedLiquidity = ({
     onIsGivenBaseChanged(true)
 
     if (val !== '') {
-      const { quoteAmount } = await calcMaxDepositAmountGivenBase(val)
-      setQuoteInput(quoteAmount)
-      onQuoteAmountChanged(quoteAmount)
-
-      // const { quote } = await previewDepositGivenBase(val, pool.rates.token0, pool.weights.token0)
-      // setQuoteInput(quote)
-      // onQuoteAmountChanged(quote)
+      let estimatedQuote = ''
+      if (pool.pooled.total > 0) {
+        const { quoteAmount } = await calcMaxDepositAmountGivenBase(val)
+        estimatedQuote = quoteAmount
+      } else {
+        const { quote } = await previewDepositGivenBase(val, pool.rates.token0, pool.weights.token0)
+        estimatedQuote = quote
+      }
+      setQuoteInput(estimatedQuote)
+      onQuoteAmountChanged(estimatedQuote)
     } else {
       setQuoteInput('')
     }

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -42,7 +42,11 @@ const MultiSidedLiquidity = ({
     pool.token0,
     pool.token1
   )
-  const { viewDeposit } = useAddRemoveLiquidity(pool.address, pool.token0, pool.token1)
+  const { viewDeposit, previewDepositGivenQuote, previewDepositGivenBase } = useAddRemoveLiquidity(
+    pool.address,
+    pool.token0,
+    pool.token1
+  )
 
   const baseTokenAmount = new TokenAmount(pool.token0, JSBI.BigInt(parseEther(baseInput !== '' ? baseInput : '0')))
   const [baseApproveState, baseApproveCallback] = useApproveCallback(baseTokenAmount, pool.address)
@@ -59,13 +63,16 @@ const MultiSidedLiquidity = ({
     onBaseAmountChanged(val)
 
     if (val !== '') {
-      const { quoteAmount } = await calcMaxDepositAmountGivenBase(val)
-      setQuoteInput(quoteAmount)
-      onQuoteAmountChanged(quoteAmount)
+      // const { quoteAmount } = await calcMaxDepositAmountGivenBase(val)
+      // setQuoteInput(quoteAmount)
+      // onQuoteAmountChanged(quoteAmount)
 
-      const input0 = Number(val)
-      const input1 = (input0 / pool.rates.token1) * pool.rates.token0 * (pool.weights.token1 / pool.weights.token0)
-      console.log('quote calculated value: ', input1)
+      // const input0 = Number(val)
+      // const input1 = (input0 / pool.rates.token1) * pool.rates.token0 * (pool.weights.token1 / pool.weights.token0)
+      // console.log('quote calculated value: ', input1)
+      const { quote } = await previewDepositGivenBase(val, pool.rates.token0)
+      setQuoteInput(quote)
+      onQuoteAmountChanged(quote)
     } else {
       setQuoteInput('')
     }
@@ -87,27 +94,41 @@ const MultiSidedLiquidity = ({
     console.log('onQuoteInputUpdate')
 
     if (val !== '') {
-      console.log('ZAP:')
-      const { maxDeposit, baseAmount } = await calcMaxDepositAmountGivenQuote(val)
-      setBaseInput(baseAmount)
-      onBaseAmountChanged(baseAmount)
+      // console.log('ZAP:')
+      // const quoteAmount = Number(val) * (100 * pool.rates.token1)
+      // console.log('quote input: ', val)
+      // console.log('quoteAmount: ', quoteAmount)
+      // const { maxDeposit, baseAmount } = await calcMaxDepositAmountGivenQuote(`${quoteAmount.toFixed(6)}`)
+      // setBaseInput(baseAmount)
+      // onBaseAmountChanged(baseAmount)
 
       // await viewDeposit(parseEther(maxDeposit))
 
-      console.log('MANUAL:')
-      const input1 = Number(val)
-      //const input0 = (input1 / pool.rates.token0) * pool.rates.token1 * (pool.weights.token0 / pool.weights.token1)
-      const input0 = (input1 / pool.rates.token0) * pool.rates.token1
-      // base = (100 / 0.0118463) * 0.0100065745 * (0.47734119 / 0.5226588)
-      console.log('base calculated value: ', input0)
+      // console.log('MANUAL:')
+      // const input1 = Number(val)
+      // console.log('input1 as string: ', val)
+      // console.log('input1 as Number: ', input1)
+      // // const input0 = (input1 / pool.rates.token0) * pool.rates.token1 * (pool.weights.token0 / pool.weights.token1)
+      // const input0 = ((pool.weights.token0 / pool.weights.token1) * input1 * pool.rates.token1) / pool.rates.token0
+      // // base = (100 / 0.0118463) * 0.0100065745 * (0.47734119 / 0.5226588)
+      // console.log('base calculated value: ', input0)
 
-      // const totalNumeraire =
-      //   input0 * (pool.rates.token0 * 100) * (pool.weights.token0 / pool.weights.token1) +
-      //   input1 * (pool.rates.token1 * 100) * (pool.weights.token1 / pool.weights.token0)
-      const totalNumeraire = input0 * (pool.rates.token0 * 100) + input1 * (pool.rates.token1 * 100)
-      console.log('calculated deposit amount: ', totalNumeraire)
+      // // const totalNumeraire =
+      // //   input0 * (pool.rates.token0 * 100) * (pool.weights.token0 / pool.weights.token1) +
+      // //   input1 * (pool.rates.token1 * 100) * (pool.weights.token1 / pool.weights.token0)
+      // // const totalNumeraire = input0 * (pool.rates.token0 * 100) + input1 * (pool.rates.token1 * 100)
+      // const totalNumeraire = input1 * (pool.rates.token1 * 100) * ((pool.weights.token0 / pool.weights.token1) * 2)
+      // console.log('calculated deposit amount: ', totalNumeraire)
 
-      await viewDeposit(parseEther(`${totalNumeraire}`))
+      // await viewDeposit(parseEther(`${totalNumeraire}`))
+
+      // const totalNumeraire2 = input1 * 2
+      // console.log('calculated deposit amount2: ', totalNumeraire2)
+      // await viewDeposit(parseEther(`${totalNumeraire2}`))
+
+      const { base } = await previewDepositGivenQuote(val, pool.rates.token1, pool.rates.token0)
+      setBaseInput(base)
+      onBaseAmountChanged(base)
     } else {
       setBaseInput('')
     }

--- a/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
@@ -25,7 +25,7 @@ interface SingleSidedLiquidityProps {
   pool: PoolData
   balances: Array<TokenAmount | undefined>
   onZapAmountChanged: (amount: string) => void
-  onZapFromBaseChanged: (fromBase: boolean) => void
+  onIsGivenBaseChanged: (isGivenBase: boolean) => void
   onSlippageChanged: (slippage: string) => void
   onDeposit: () => void
 }
@@ -34,7 +34,7 @@ const SingleSidedLiquidity = ({
   pool,
   balances,
   onZapAmountChanged,
-  onZapFromBaseChanged,
+  onIsGivenBaseChanged,
   onSlippageChanged,
   onDeposit
 }: SingleSidedLiquidityProps) => {
@@ -118,7 +118,7 @@ const SingleSidedLiquidity = ({
           tokenList={[pool.token0, pool.token1]}
           onSelectToken={token => {
             setSelectedToken(token)
-            onZapFromBaseChanged(token === pool.token0)
+            onIsGivenBaseChanged(token === pool.token0)
             onBaseInputUpdate(zapInput)
           }}
         />

--- a/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
@@ -43,7 +43,7 @@ const SingleSidedLiquidity = ({
   const [zapInput, setZapInput] = useState('')
   const [baseAmount, setBaseAmount] = useState('')
   const [quoteAmount, setQuoteAmount] = useState('')
-  const [slippage, setSlippage] = useState('0.1')
+  const [slippage, setSlippage] = useState('0.5')
 
   const { calcSwapAmountForZapFromBase, calcSwapAmountForZapFromQuote } = useZap(pool.address, pool.token0, pool.token1)
   const { viewOriginSwap, viewTargetSwap } = useSwap(pool)

--- a/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
@@ -44,6 +44,7 @@ const SingleSidedLiquidity = ({
   const [baseAmount, setBaseAmount] = useState('')
   const [quoteAmount, setQuoteAmount] = useState('')
   const [slippage, setSlippage] = useState('0.5')
+  const [isGivenBase, setIsGivenBase] = useState(true)
 
   const { calcSwapAmountForZapFromBase, calcSwapAmountForZapFromQuote } = useZap(pool.address, pool.token0, pool.token1)
   const { viewOriginSwap, viewTargetSwap } = useSwap(pool)
@@ -89,7 +90,7 @@ const SingleSidedLiquidity = ({
       const baseBalance = balances[0] ? Number(balances[0].toExact()) : 0
       const quoteBalance = balances[1] ? Number(balances[1]?.toExact()) : 0
 
-      if (baseBalance < Number(baseAmount) || quoteBalance < Number(quoteAmount)) {
+      if ((isGivenBase && baseBalance < Number(baseAmount)) || (!isGivenBase && quoteBalance < Number(quoteAmount))) {
         setMainState(AddLiquidityState.InsufficientBalance)
       } else if (!baseZapApproved || !quoteZapApproved) {
         setMainState(AddLiquidityState.NotApproved)
@@ -101,7 +102,11 @@ const SingleSidedLiquidity = ({
     } else {
       setMainState(AddLiquidityState.NoAmount)
     }
-  }, [zapInput, baseZapApproved, quoteZapApproved, balances, baseAmount, quoteAmount, slippage])
+  }, [zapInput, baseZapApproved, quoteZapApproved, balances, baseAmount, quoteAmount, slippage, isGivenBase])
+
+  useEffect(() => {
+    onIsGivenBaseChanged(isGivenBase)
+  }, [isGivenBase])
 
   return (
     <>
@@ -118,7 +123,7 @@ const SingleSidedLiquidity = ({
           tokenList={[pool.token0, pool.token1]}
           onSelectToken={token => {
             setSelectedToken(token)
-            onIsGivenBaseChanged(token === pool.token0)
+            setIsGivenBase(token === pool.token0)
             onBaseInputUpdate(zapInput)
           }}
         />

--- a/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/SingleSidedLiquidity.tsx
@@ -104,10 +104,6 @@ const SingleSidedLiquidity = ({
     }
   }, [zapInput, baseZapApproved, quoteZapApproved, balances, baseAmount, quoteAmount, slippage, isGivenBase])
 
-  useEffect(() => {
-    onIsGivenBaseChanged(isGivenBase)
-  }, [isGivenBase])
-
   return (
     <>
       <div className="mt-2 text-right italic text-xs text-gray-400 md:hidden">Swaps will be carried out for you</div>
@@ -123,8 +119,10 @@ const SingleSidedLiquidity = ({
           tokenList={[pool.token0, pool.token1]}
           onSelectToken={token => {
             setSelectedToken(token)
-            setIsGivenBase(token === pool.token0)
             onBaseInputUpdate(zapInput)
+            const isTokenBase = token === pool.token0
+            setIsGivenBase(isTokenBase)
+            onIsGivenBaseChanged(isTokenBase)
           }}
         />
       </div>

--- a/src/pages/Tailwind/Pool/models/PoolData.ts
+++ b/src/pages/Tailwind/Pool/models/PoolData.ts
@@ -22,4 +22,5 @@ export interface PoolData {
   staked: number
   earned: number
   totalSupply: number
+  assimilators: string[]
 }

--- a/src/pages/Test/TailwindDemo.tsx
+++ b/src/pages/Test/TailwindDemo.tsx
@@ -88,9 +88,9 @@ const TailwindDemo = () => {
       {/* ================================ */}
       <PageWrapper className="mb-8">
         <div className="text-xl font-bold">Page header (filled)</div>
-        <div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:space-x-16 md:items-center">
+        <div className="flex flex-col space-y-4 md:flex-row md:space-y-0 md:items-center">
           {/* Left side */}
-          <div className="md:w-1/2">
+          <div className="md:w-1/2 md:pr-16">
             <PageHeaderLeft
               subtitle="Add/Remove Liquidity"
               title="Pools"


### PR DESCRIPTION
## Description of Changes

For calculating deposit amount:
- if user entered quote amount, use `Curve.viewDeposit()` 
- if user entered base amount
  - if there's no liquidity yet, use `Curve.viewDeposit()` 
  - if there's liquidity, use `Zap.calcMaxDepositAmountGivenBase()` 

Also some bug fixes & improvements throughout Add Liquidity feature
- fixed displayed tokenA:tokenB price on confirm add liquidity modal
- removed 0.1% option from slippage component (default slippage is now 0.5%)
- fixed tokenA tokenB displaying as 0 when single side add liquidity is in progress
- improved spacing on liquidity page header
- fixed staked HLPs & earned xRNBW not showing for first pool/row & summary
- disabled single sided add liquidity if pool has no liquidity yet

[Link to Jira Ticket](https://halodao.atlassian.net/browse/HDB-18)


### Developer Checklist:

* [ ] I have followed the guidelines in our Contributing document
* [ ] This PR has a corresponding JIRA ticket
* [ ] My branch conforms with our naming convention i.e. `feature/HDF-XXX-description`
* [ ] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [ ] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
