### PR TITLE
Temp UI adjustment for double estimates

### DIFF
--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -76,7 +76,9 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
     async (quoteAmount: string) => {
       const quoteNumeraire = Number(quoteAmount)
       const totalNumeraire = quoteNumeraire * 2
+      console.log('totalNumeraire ', totalNumeraire)
       const { lpToken, base, quote } = await viewDeposit(parseEther(`${totalNumeraire}`))
+      console.log('previewDepositGivenQuote: base ', base, ', quote ', quote)
       return {
         deposit: totalNumeraire,
         lpToken,
@@ -92,6 +94,7 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
       const baseNumeraire = Number(baseAmount) * baseRate
       const totalNumeraire = baseNumeraire * (baseWeight > 0 ? 1 / baseWeight : 2)
       const { lpToken, base, quote } = await viewDeposit(parseEther(`${totalNumeraire}`))
+      console.log('previewDepositGivenBase: base ', base, ', quote ', quote)
       return {
         deposit: totalNumeraire,
         lpToken,

--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -94,7 +94,6 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
       const baseNumeraire = Number(baseAmount) * baseRate
       const totalNumeraire = baseNumeraire * (baseWeight > 0 ? 1 / baseWeight : 2)
       const { lpToken, base, quote } = await viewDeposit(parseEther(`${totalNumeraire}`))
-      console.log('previewDepositGivenBase: base ', base, ', quote ', quote)
       return {
         deposit: totalNumeraire,
         lpToken,

--- a/src/halo-hooks/amm/useZap.ts
+++ b/src/halo-hooks/amm/useZap.ts
@@ -62,6 +62,10 @@ export const useZap = (curveAddress: string, token0: Token, token1: Token) => {
       //   formatUnits(res[2][0], token0.decimals),
       //   formatUnits(res[2][1], token1.decimals)
       // )
+      console.log('calcMaxDepositAmountGivenQuote maxDeposit:', formatEther(res[0]))
+      console.log('calcMaxDepositAmountGivenQuote lpAmount:', formatEther(res[1]))
+      console.log('calcMaxDepositAmountGivenQuote baseAmount:', formatUnits(res[2][0], token0.decimals))
+      console.log('calcMaxDepositAmountGivenQuote quoteAmount:', formatUnits(res[2][1], token1.decimals))
 
       return {
         maxDeposit: formatEther(res[0]),

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -52,15 +52,7 @@ const MultiSidedLiquidity = ({
   const baseApproved = baseApproveState === ApprovalState.APPROVED
   const quoteApproved = quoteApproveState === ApprovalState.APPROVED
 
-  /**
-   * Update quote amount upon entering base amount
-   **/
-  const onBaseInputUpdate = async (val: string) => {
-    console.log('onBaseInputUpdate ', val)
-    setBaseInput(val)
-    onBaseAmountChanged(val)
-    onIsGivenBaseChanged(true)
-
+  const inputIsZero = async (val: string) => {
     let zeroStr = 0,
       valIsZero = false
     try {
@@ -71,7 +63,19 @@ const MultiSidedLiquidity = ({
       console.log('zero check failed')
     }
 
-    if (val !== '' && !valIsZero) {
+    return valIsZero
+  }
+
+  /**
+   * Update quote amount upon entering base amount
+   **/
+  const onBaseInputUpdate = async (val: string) => {
+    console.log('onBaseInputUpdate ', val)
+    setBaseInput(val)
+    onBaseAmountChanged(val)
+    onIsGivenBaseChanged(true)
+
+    if (val !== '' && !inputIsZero(val)) {
       let estimatedQuote = ''
       if (pool.pooled.total <= 1) {
         console.log('liquidity is < 1')
@@ -113,17 +117,7 @@ const MultiSidedLiquidity = ({
     onQuoteAmountChanged(val)
     onIsGivenBaseChanged(false)
 
-    let zeroStr = 0,
-      valIsZero = false
-    try {
-      zeroStr = parseFloat(val)
-      console.log('zeroStr ', zeroStr)
-      if (zeroStr == 0) valIsZero = true
-    } catch (err) {
-      console.log('zero check failed')
-    }
-
-    if (val !== '' && !valIsZero) {
+    if (val !== '' && !inputIsZero(val)) {
       // const { baseAmount } = await calcMaxDepositAmountGivenQuote(val)
       // setBaseInput(baseAmount)
       // onBaseAmountChanged(baseAmount)

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -52,59 +52,64 @@ const MultiSidedLiquidity = ({
   const baseApproved = baseApproveState === ApprovalState.APPROVED
   const quoteApproved = quoteApproveState === ApprovalState.APPROVED
 
+  // move this somewhere better in the state
+  const shouldLog = false
+
   const inputIsZero = async (val: string) => {
     let zeroStr = 0,
       valIsZero = false
     try {
       zeroStr = parseFloat(val)
-      console.log('zeroStr ', zeroStr)
+      if (shouldLog) console.log('zeroStr ', zeroStr)
       if (zeroStr == 0) valIsZero = true
     } catch (err) {
-      console.log('zero check failed')
+      if (shouldLog) console.log('zero check failed')
     }
 
     return valIsZero
   }
 
   const adjustBaseOrQuoteForEstimationErr = async (val: string, base: string, quote: string, valIsBase: boolean) => {
-    console.log('adjustBaseOrQuoteForEstimationErr ', adjustBaseOrQuoteForEstimationErr)
+    if (shouldLog) console.log('adjustBaseOrQuoteForEstimationErr ', adjustBaseOrQuoteForEstimationErr)
     let estimated = ''
 
     if (valIsBase) {
       try {
         const numberVal = parseFloat(val)
-        console.log('numberVal ', numberVal)
+        if (shouldLog) console.log('numberVal ', numberVal)
         const numberBase = parseFloat(base)
-        console.log('numberBase ', numberBase)
+        if (shouldLog) console.log('numberBase ', numberBase)
         const numberQuote = parseFloat(quote)
         const rateOfErr = numberVal / numberBase
-        console.log('rateOfErr ', rateOfErr)
+        if (shouldLog) console.log('rateOfErr ', rateOfErr)
         const quoteAdjustedForErr = numberQuote * rateOfErr
-        console.log('quoteAdjustedForErr ', quoteAdjustedForErr)
+        if (shouldLog) console.log('quoteAdjustedForErr ', quoteAdjustedForErr)
         estimated = quoteAdjustedForErr.toString()
-        console.log('estimatedQuote adjusted for err ', estimated)
+        if (shouldLog) console.log('estimatedQuote adjusted for err ', estimated)
       } catch (err) {
-        console.log('onBaseInputUpdate: quote normalization failed, not changing quote returned by viewDeposit')
+        if (shouldLog)
+          console.log('onBaseInputUpdate: quote normalization failed, not changing quote returned by viewDeposit')
         estimated = quote
-        console.log('estimatedQuote NOT adjusted for err ', estimated)
+        if (shouldLog) console.log('estimatedQuote NOT adjusted for err ', estimated)
       }
     } else {
       try {
         const numberVal = parseFloat(val)
-        console.log('numberVal ', numberVal)
+        if (shouldLog) console.log('numberVal ', numberVal)
         const numberQuote = parseFloat(quote)
-        console.log('numberQuote ', numberQuote)
+        if (shouldLog) console.log('numberQuote ', numberQuote)
         const numberBase = parseFloat(base)
         const rateOfErr = numberVal / numberQuote
-        console.log('rateOfErr ', rateOfErr)
+        if (shouldLog) console.log('rateOfErr ', rateOfErr)
         const baseAdjustedForErr = numberBase * rateOfErr
-        console.log('baseAdjustedForErr ', baseAdjustedForErr)
+        if (shouldLog) console.log('baseAdjustedForErr ', baseAdjustedForErr)
         estimated = baseAdjustedForErr.toString()
-        console.log('estimatedBase adjusted for err ', estimated)
+        if (shouldLog) console.log('estimatedBase adjusted for err ', estimated)
       } catch (err) {
-        console.log('onBaseInputUpdate: quote normalization failed, not changing quote returned by viewDeposit')
+        if (shouldLog)
+          console.log('onBaseInputUpdate: quote normalization failed, not changing quote returned by viewDeposit')
         estimated = base
-        console.log('estimatedBase NOT adjusted for err ', estimated)
+        if (shouldLog) console.log('estimatedBase NOT adjusted for err ', estimated)
       }
     }
 
@@ -115,21 +120,21 @@ const MultiSidedLiquidity = ({
    * Update quote amount upon entering base amount
    **/
   const onBaseInputUpdate = async (val: string) => {
-    console.log('onBaseInputUpdate ', val)
+    if (shouldLog) console.log('onBaseInputUpdate ', val)
     setBaseInput(val)
     onBaseAmountChanged(val)
     onIsGivenBaseChanged(true)
 
     const inputZero = await inputIsZero(val)
-    console.log('inputIsZero ', inputZero)
+    if (shouldLog) console.log('inputIsZero ', inputZero)
     if (val !== '' && !inputZero) {
       let estimatedQuote = ''
       if (pool.pooled.total <= 1) {
-        console.log('liquidity is < 1')
+        if (shouldLog) console.log('liquidity is < 1')
         const { quoteAmount } = await calcMaxDepositAmountGivenBase(val)
         estimatedQuote = quoteAmount
       } else {
-        console.log('liquidity is > 1')
+        if (shouldLog) console.log('liquidity is > 1')
         const { base, quote } = await previewDepositGivenBase(val, pool.rates.token0, pool.weights.token0)
         estimatedQuote = await adjustBaseOrQuoteForEstimationErr(val, base, quote, true)
       }
@@ -149,7 +154,7 @@ const MultiSidedLiquidity = ({
     onIsGivenBaseChanged(false)
 
     const inputZero = await inputIsZero(val)
-    console.log('inputIsZero ', inputZero)
+    if (shouldLog) console.log('inputIsZero ', inputZero)
     if (val !== '' && !inputZero) {
       // const { baseAmount } = await calcMaxDepositAmountGivenQuote(val)
       // setBaseInput(baseAmount)

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -61,7 +61,17 @@ const MultiSidedLiquidity = ({
     onBaseAmountChanged(val)
     onIsGivenBaseChanged(true)
 
-    if (val !== '') {
+    let zeroStr = 0,
+      valIsZero = false
+    try {
+      zeroStr = parseFloat(val)
+      console.log('zeroStr ', zeroStr)
+      if (zeroStr == 0) valIsZero = true
+    } catch (err) {
+      console.log('zero check failed')
+    }
+
+    if (val !== '' && !valIsZero) {
       let estimatedQuote = ''
       if (pool.pooled.total <= 1) {
         console.log('liquidity is < 1')
@@ -103,7 +113,17 @@ const MultiSidedLiquidity = ({
     onQuoteAmountChanged(val)
     onIsGivenBaseChanged(false)
 
-    if (val !== '') {
+    let zeroStr = 0,
+      valIsZero = false
+    try {
+      zeroStr = parseFloat(val)
+      console.log('zeroStr ', zeroStr)
+      if (zeroStr == 0) valIsZero = true
+    } catch (err) {
+      console.log('zero check failed')
+    }
+
+    if (val !== '' && !valIsZero) {
       // const { baseAmount } = await calcMaxDepositAmountGivenQuote(val)
       // setBaseInput(baseAmount)
       // onBaseAmountChanged(baseAmount)


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Description of Changes
<!-- Enter description of changes here. -->

- changed the conditional here, iirc we wanted to call `viewDeposit` when there's **already** liquidity in the pool https://github.com/HaloDAO/halodao-interface/blob/1a82f0c7675cb12f7956d398edfa9113e1d61f17/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx#L66
- added messy hotfix here https://github.com/HaloDAO/halodao-interface/blob/1a82f0c7675cb12f7956d398edfa9113e1d61f17/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx#L73 and here https://github.com/HaloDAO/halodao-interface/blob/1a82f0c7675cb12f7956d398edfa9113e1d61f17/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx#L116 to normalize non consistent `viewDeposit` double return values (see [viewDeposit unit test](https://github.com/dfx-finance/protocol/blob/8279479cd16f716a8a306e8f40a42cbf22e08b62/test/Curve.test.ts#L535) of dfx that actually divide `viewDeposit` return vals by 2)

Note for reviewers:

1. i've only tested this against actually adding liquidity into Polygon xSGD:USDC after the estimate. Please test on kovan the ff:
- empty a pool and try to add liquidity and see the estimate
- add to existing low liquidity pools (like 100 USD equivalent) and see that rate is accurate
- add to existing high liquidity pools (like 100,000 USD equivalent) and see that rate is accurate

1. After this quick fix, we need to write a unit test that calls `viewDeposit(_deposit)` with varying amounts of `(_deposit)` and incrementally increasing `Curve.liquidity()` and observe the returned base and quote


### Developer Checklist:

* [ ] I have followed the guidelines in our Contributing document
* [ ] This PR has a corresponding JIRA ticket
* [ ] My branch conforms with our naming convention i.e. `feature/HDEV-XXX-description`
* [ ] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [x] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
