### PR TITLE
Added inactive pools feature on Liquidity Pools page

### DIFF
--- a/src/pages/Tailwind/Pool/ExpandablePoolRow.tsx
+++ b/src/pages/Tailwind/Pool/ExpandablePoolRow.tsx
@@ -49,9 +49,10 @@ interface ExpandablePoolRowProps {
   pid?: number
   isExpanded: boolean
   onClick: () => void
+  isActivePool?: boolean
 }
 
-const ExpandablePoolRow = ({ poolAddress, pid, isExpanded, onClick }: ExpandablePoolRowProps) => {
+const ExpandablePoolRow = ({ poolAddress, pid, isExpanded, onClick, isActivePool = true }: ExpandablePoolRowProps) => {
   const [pool, setPool] = useState<PoolData | undefined>(undefined)
   const { getTokens, getLiquidity, getBalance, getStakedLPToken, getPendingRewards, getTotalSupply } = useLiquidityPool(
     poolAddress,
@@ -212,7 +213,7 @@ const ExpandablePoolRow = ({ poolAddress, pid, isExpanded, onClick }: Expandable
         <div className="mt-2">
           <div className="flex flex-col md:flex-row md:space-x-4">
             <div className="mb-4 md:w-1/2 md:mb-0">
-              <PoolCardLeft pool={pool} />
+              <PoolCardLeft pool={pool} isActivePool={isActivePool} />
             </div>
             <div className="md:w-1/2">
               <PoolCardRight pool={pool} />

--- a/src/pages/Tailwind/Pool/PoolCardLeft.tsx
+++ b/src/pages/Tailwind/Pool/PoolCardLeft.tsx
@@ -6,9 +6,10 @@ import { PoolData } from './models/PoolData'
 
 interface PoolCardLeftProps {
   pool: PoolData
+  isActivePool: boolean
 }
 
-const PoolCardLeft = ({ pool }: PoolCardLeftProps) => {
+const PoolCardLeft = ({ pool, isActivePool }: PoolCardLeftProps) => {
   const [activeTab, setActiveTab] = useState(0)
   const [disabledTabs, setDisabledTabs] = useState<number[]>([])
 
@@ -36,7 +37,7 @@ const PoolCardLeft = ({ pool }: PoolCardLeftProps) => {
       />
 
       <div className="mt-2">
-        {activeTab === 0 && <AddLiquidity pool={pool} />}
+        {activeTab === 0 && <AddLiquidity pool={pool} isEnabled={isActivePool} />}
         {activeTab === 1 && <RemoveLiquidity pool={pool} />}
       </div>
     </div>

--- a/src/pages/Tailwind/Pool/PoolTable.tsx
+++ b/src/pages/Tailwind/Pool/PoolTable.tsx
@@ -1,0 +1,37 @@
+import React, { useState } from 'react'
+import { PoolAddressPidMap } from '.'
+import ExpandablePoolRow from './ExpandablePoolRow'
+
+interface PoolTableProps {
+  poolMap: PoolAddressPidMap[]
+  isActivePools: boolean
+}
+
+const PoolTable = ({ poolMap, isActivePools }: PoolTableProps) => {
+  const [activeRow, setActiveRow] = useState(0)
+  const [isExpanded, setIsExpanded] = useState(false)
+
+  return (
+    <>
+      {poolMap.map((pool, i) => (
+        <ExpandablePoolRow
+          key={pool.address}
+          poolAddress={pool.address}
+          pid={pool.pid}
+          isExpanded={activeRow === i ? isExpanded : false}
+          onClick={() => {
+            if (activeRow === i) {
+              setIsExpanded(!isExpanded)
+            } else {
+              setIsExpanded(true)
+              setActiveRow(i)
+            }
+          }}
+          isActivePool={isActivePools}
+        />
+      ))}
+    </>
+  )
+}
+
+export default PoolTable

--- a/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/AddLiquidity.tsx
@@ -9,16 +9,17 @@ import AddLiquityModal from './AddLiquityModal'
 
 interface AddLiquidityProps {
   pool: PoolData
+  isEnabled: boolean
 }
 
-const AddLiquidity = ({ pool }: AddLiquidityProps) => {
+const AddLiquidity = ({ pool, isEnabled }: AddLiquidityProps) => {
   const [activeSegment, setActiveSegment] = useState(0)
   const [showModal, setShowModal] = useState(false)
   const [baseAmount, setBaseAmount] = useState('')
   const [quoteAmount, setQuoteAmount] = useState('')
   const [zapAmount, setZapAmount] = useState('')
   const [isGivenBase, setIsGivenBase] = useState(false)
-  const [slippage, setSlippage] = useState('')
+  const [slippage, setSlippage] = useState('3')
 
   const { account } = useActiveWeb3React()
   const tokenBalances = useTokenBalances(account ?? undefined, [pool.token0, pool.token1])
@@ -48,6 +49,7 @@ const AddLiquidity = ({ pool }: AddLiquidityProps) => {
           onQuoteAmountChanged={setQuoteAmount}
           onDeposit={() => setShowModal(true)}
           onIsGivenBaseChanged={setIsGivenBase}
+          isAddLiquidityEnabled={isEnabled}
         />
       ) : (
         <SingleSidedLiquidity
@@ -57,6 +59,7 @@ const AddLiquidity = ({ pool }: AddLiquidityProps) => {
           onIsGivenBaseChanged={setIsGivenBase}
           onSlippageChanged={setSlippage}
           onDeposit={() => setShowModal(true)}
+          isAddLiquidityEnabled={isEnabled}
         />
       )}
 

--- a/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
+++ b/src/pages/Tailwind/Pool/liquidity/MultiSidedLiquidity.tsx
@@ -14,7 +14,8 @@ enum AddLiquidityState {
   InsufficientBalance,
   NotApproved,
   Approved,
-  Depositing
+  Depositing,
+  Disabled
 }
 
 interface MultiSidedLiquidityProps {
@@ -24,6 +25,7 @@ interface MultiSidedLiquidityProps {
   onQuoteAmountChanged: (quoteAmount: string) => void
   onDeposit: () => void
   onIsGivenBaseChanged: (isGivenBase: boolean) => void
+  isAddLiquidityEnabled: boolean
 }
 
 const MultiSidedLiquidity = ({
@@ -32,7 +34,8 @@ const MultiSidedLiquidity = ({
   onBaseAmountChanged,
   onQuoteAmountChanged,
   onDeposit,
-  onIsGivenBaseChanged
+  onIsGivenBaseChanged,
+  isAddLiquidityEnabled
 }: MultiSidedLiquidityProps) => {
   const [mainState, setMainState] = useState<AddLiquidityState>(AddLiquidityState.NoAmount)
   const [baseInput, setBaseInput] = useState('')
@@ -101,7 +104,9 @@ const MultiSidedLiquidity = ({
    * Logic for updating "Supply" button
    **/
   useEffect(() => {
-    if (baseInput !== '' && quoteInput !== '') {
+    if (!isAddLiquidityEnabled) {
+      setMainState(AddLiquidityState.Disabled)
+    } else if (baseInput !== '' && quoteInput !== '') {
       const baseBalance = balances[0] ? Number(balances[0].toExact()) : 0
       const quoteBalance = balances[1] ? Number(balances[1]?.toExact()) : 0
 
@@ -115,7 +120,7 @@ const MultiSidedLiquidity = ({
     } else {
       setMainState(AddLiquidityState.NoAmount)
     }
-  }, [baseInput, quoteInput, baseApproved, quoteApproved, balances])
+  }, [isAddLiquidityEnabled, baseInput, quoteInput, baseApproved, quoteApproved, balances])
 
   return (
     <>
@@ -140,7 +145,7 @@ const MultiSidedLiquidity = ({
         />
       </div>
 
-      {(!baseApproved || !quoteApproved) && (
+      {(!baseApproved || !quoteApproved) && isAddLiquidityEnabled && (
         <div className="mt-4 flex space-x-4">
           {!baseApproved && (
             <div className={!quoteApproved ? 'w-1/2' : 'flex-1'}>
@@ -183,14 +188,18 @@ const MultiSidedLiquidity = ({
         <PrimaryButton
           type={PrimaryButtonType.Gradient}
           title={
-            mainState === AddLiquidityState.NoAmount
+            mainState === AddLiquidityState.Disabled
+              ? 'Add Liquidity Disabled'
+              : mainState === AddLiquidityState.NoAmount
               ? 'Enter an amount'
               : mainState === AddLiquidityState.InsufficientBalance
               ? 'Insufficient Balance'
               : 'Supply'
           }
           state={
-            mainState === AddLiquidityState.Approved
+            mainState === AddLiquidityState.Disabled
+              ? PrimaryButtonState.Disabled
+              : mainState === AddLiquidityState.Approved
               ? PrimaryButtonState.Enabled
               : mainState === AddLiquidityState.Depositing
               ? PrimaryButtonState.InProgress


### PR DESCRIPTION
## Description of Changes

- Add an "Inactive Pools" section on Liquidity Pools page
- Minor bugfix: default slippage on single sided liquidity set to 3%

### Developer Checklist:

* [ ] I have followed the guidelines in our Contributing document
* [ ] This PR has a corresponding JIRA ticket
* [ ] My branch conforms with our naming convention i.e. `feature/HDEV-XXX-description`
* [ ] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [ ] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
