### PR TITLE
hdev-241-fetch-vesting-apy-price-from-mainnet

### DIFF
--- a/src/connectors/index.ts
+++ b/src/connectors/index.ts
@@ -9,7 +9,7 @@ import { FortmaticConnector } from './Fortmatic'
 import { NetworkConnector } from './NetworkConnector'
 import { ChainId } from '@sushiswap/sdk'
 
-const RPC = {
+export const RPC = {
   [ChainId.MAINNET]: `https://mainnet.infura.io/v3/${process.env.REACT_APP_INFURA_API_KEY}`,
   [ChainId.ROPSTEN]: `https://ropsten.infura.io/v3/${process.env.REACT_APP_INFURA_API_KEY}`,
   [ChainId.RINKEBY]: `https://rinkeby.infura.io/v3/${process.env.REACT_APP_INFURA_API_KEY}`,

--- a/src/halo-hooks/useHaloHalo.ts
+++ b/src/halo-hooks/useHaloHalo.ts
@@ -25,7 +25,7 @@ const useHaloHalo = () => {
     true,
     overrideCurrentProvider
   ) // withSigner
-  const halohaloContract = useContract(haloHaloAddress || '', HALOHALO_ABI, true, overrideCurrentProvider) // withSigner
+  const halohaloContract = useContract(haloHaloAddress, HALOHALO_ABI, true, overrideCurrentProvider) // withSigner
   const [allowance, setAllowance] = useState('0')
   const [haloHaloAPY, setHaloHaloAPY] = useState(0)
   const [haloHaloPrice, setHaloHaloPrice] = useState('0')

--- a/src/halo-hooks/useHaloHalo.ts
+++ b/src/halo-hooks/useHaloHalo.ts
@@ -17,7 +17,7 @@ const useHaloHalo = () => {
   const { account, chainId } = useActiveWeb3React()
   const addTransaction = useTransactionAdder()
   const overrideCurrentProvider = chainId && chainId === ChainId.MATIC ? true : false // user RPCProvider to connect to mainnet if user is in MATIC
-  const contractChainId = chainId && chainId === ChainId.MATIC ? ChainId.MAINNET : chainId
+  const contractChainId = overrideCurrentProvider ? ChainId.MAINNET : chainId
   const haloHaloAddress = chainId ? HALOHALO_ADDRESS[contractChainId as ChainId] : undefined
   const rewardsManagerAddress = chainId ? HALO_REWARDS_MANAGER_ADDRESS[contractChainId as ChainId] : undefined
   const haloContract = useTokenContract(

--- a/src/halo-hooks/useHaloHalo.ts
+++ b/src/halo-hooks/useHaloHalo.ts
@@ -2,9 +2,6 @@ import { useCallback, useState, useEffect } from 'react'
 import { ethers } from 'ethers'
 import { useTransactionAdder } from '../state/transactions/hooks'
 import { useActiveWeb3React } from '../hooks'
-import { useWeb3React } from '@web3-react/core'
-import { NetworkContextName } from '../constants'
-import { network } from '../connectors'
 
 import Fraction from '../constants/Fraction'
 import { BalanceProps } from '../sushi-hooks/queries/useTokenBalance'
@@ -19,16 +16,16 @@ const { BigNumber } = ethers
 const useHaloHalo = () => {
   const { account, chainId } = useActiveWeb3React()
   const addTransaction = useTransactionAdder()
-
+  const overrideCurrentProvider = chainId && chainId === ChainId.MATIC ? true : false // user RPCProvider to connect to mainnet if user is in MATIC
   const contractChainId = chainId && chainId === ChainId.MATIC ? ChainId.MAINNET : chainId
-  console.log('contractChainId', contractChainId)
   const haloHaloAddress = chainId ? HALOHALO_ADDRESS[contractChainId as ChainId] : undefined
   const rewardsManagerAddress = chainId ? HALO_REWARDS_MANAGER_ADDRESS[contractChainId as ChainId] : undefined
-  console.log('rewardsManagerAddress', rewardsManagerAddress)
-  const haloContract = useTokenContract(chainId ? HALO_TOKEN_ADDRESS[contractChainId as ChainId] : undefined || '') // withSigner
-  const halohaloContract = useContract(haloHaloAddress || '', HALOHALO_ABI) // withSigner
-  console.log('haloContract', haloContract)
-  console.log('halohaloContract', halohaloContract)
+  const haloContract = useTokenContract(
+    chainId ? HALO_TOKEN_ADDRESS[contractChainId as ChainId] : undefined || '',
+    true,
+    overrideCurrentProvider
+  ) // withSigner
+  const halohaloContract = useContract(haloHaloAddress || '', HALOHALO_ABI, true, overrideCurrentProvider) // withSigner
   const [allowance, setAllowance] = useState('0')
   const [haloHaloAPY, setHaloHaloAPY] = useState(0)
   const [haloHaloPrice, setHaloHaloPrice] = useState('0')

--- a/src/halo-hooks/useHaloHalo.ts
+++ b/src/halo-hooks/useHaloHalo.ts
@@ -21,7 +21,7 @@ const useHaloHalo = () => {
   const haloHaloAddress = chainId ? HALOHALO_ADDRESS[contractChainId as ChainId] : undefined
   const rewardsManagerAddress = chainId ? HALO_REWARDS_MANAGER_ADDRESS[contractChainId as ChainId] : undefined
   const haloContract = useTokenContract(
-    chainId ? HALO_TOKEN_ADDRESS[contractChainId as ChainId] : undefined || '',
+    chainId ? HALO_TOKEN_ADDRESS[contractChainId as ChainId] : undefined,
     true,
     overrideCurrentProvider
   ) // withSigner

--- a/src/hooks/useContract.ts
+++ b/src/hooks/useContract.ts
@@ -31,7 +31,12 @@ import { useActiveWeb3React } from './index'
 import HALO_REWARDS_ABI from '../constants/haloAbis/Rewards.json'
 
 // returns null on errors
-export function useContract(address: string | undefined, ABI: any, withSignerIfPossible = true): Contract | null {
+export function useContract(
+  address: string | undefined,
+  ABI: any,
+  withSignerIfPossible = true,
+  overrideCurrentProvider?: boolean
+): Contract | null {
   const { library, account } = useActiveWeb3React()
 
   return useMemo(() => {
@@ -39,12 +44,18 @@ export function useContract(address: string | undefined, ABI: any, withSignerIfP
       return null
     }
     try {
-      return getContract(address, ABI, library, withSignerIfPossible && account ? account : undefined)
+      return getContract(
+        address,
+        ABI,
+        library,
+        withSignerIfPossible && account ? account : undefined,
+        overrideCurrentProvider
+      )
     } catch (error) {
       console.error('Failed to get contract', error)
       return null
     }
-  }, [address, ABI, library, withSignerIfPossible, account])
+  }, [address, ABI, library, withSignerIfPossible, account, overrideCurrentProvider])
 }
 
 export function useV1FactoryContract(): Contract | null {
@@ -60,8 +71,12 @@ export function useV1ExchangeContract(address?: string, withSignerIfPossible?: b
   return useContract(address, V1_EXCHANGE_ABI, withSignerIfPossible)
 }
 
-export function useTokenContract(tokenAddress?: string, withSignerIfPossible?: boolean): Contract | null {
-  return useContract(tokenAddress, ERC20_ABI, withSignerIfPossible)
+export function useTokenContract(
+  tokenAddress?: string,
+  withSignerIfPossible?: boolean,
+  overrideCurrentProvider?: boolean
+): Contract | null {
+  return useContract(tokenAddress, ERC20_ABI, withSignerIfPossible, overrideCurrentProvider)
 }
 
 export function useWETHContract(withSignerIfPossible?: boolean): Contract | null {

--- a/src/pages/HaloHalo/index.tsx
+++ b/src/pages/HaloHalo/index.tsx
@@ -276,12 +276,15 @@ export default function HaloHalo() {
                       <HaloIngredients src={xRnbwTokenIcon} alt="RNBW" />
                       <HaloHaloPairText id="haloHaloPrice">xRNBW : </HaloHaloPairText>
                       <HaloIngredients src={RnbwTokenIcon} alt="RNBW" />
-                      <HaloHaloPairText id="haloHaloPrice">
-                        RNBW = x{haloHaloPrice} {!features?.vest && ` (Ethereum mainnet)`}
-                      </HaloHaloPairText>
+                      <HaloHaloPairText id="haloHaloPrice">RNBW = x{haloHaloPrice}</HaloHaloPairText>
                     </HaloPairCenterContainer>
                   </RowBetween>
                 </RowBetweenHaloPair>
+                {!features?.vest && (
+                  <HaloPairCenterContainer>
+                    <HaloHaloPairText>(Ethereum mainnet)</HaloHaloPairText>
+                  </HaloPairCenterContainer>
+                )}
               </AutoColumn>
             </AutoColumnDeposit>
           </Wrapper>

--- a/src/pages/HaloHalo/index.tsx
+++ b/src/pages/HaloHalo/index.tsx
@@ -270,18 +270,18 @@ export default function HaloHalo() {
                     <WithdrawOnUnsupportedNetwork chainId={chainId as ChainId} />
                   </div>
                 )}
-                {features?.vest && (
-                  <RowBetweenHaloPair>
-                    <RowBetween>
-                      <HaloPairCenterContainer>
-                        <HaloIngredients src={xRnbwTokenIcon} alt="RNBW" />
-                        <HaloHaloPairText id="haloHaloPrice">xRNBW : </HaloHaloPairText>
-                        <HaloIngredients src={RnbwTokenIcon} alt="RNBW" />
-                        <HaloHaloPairText id="haloHaloPrice">RNBW = x{haloHaloPrice} </HaloHaloPairText>
-                      </HaloPairCenterContainer>
-                    </RowBetween>
-                  </RowBetweenHaloPair>
-                )}
+                <RowBetweenHaloPair>
+                  <RowBetween>
+                    <HaloPairCenterContainer>
+                      <HaloIngredients src={xRnbwTokenIcon} alt="RNBW" />
+                      <HaloHaloPairText id="haloHaloPrice">xRNBW : </HaloHaloPairText>
+                      <HaloIngredients src={RnbwTokenIcon} alt="RNBW" />
+                      <HaloHaloPairText id="haloHaloPrice">
+                        RNBW = x{haloHaloPrice} {!features?.vest && ` (Ethereum mainnet)`}
+                      </HaloHaloPairText>
+                    </HaloPairCenterContainer>
+                  </RowBetween>
+                </RowBetweenHaloPair>
               </AutoColumn>
             </AutoColumnDeposit>
           </Wrapper>

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -262,7 +262,7 @@ export function getContract(
     throw Error(`Invalid 'address' parameter '${address}'.`)
   }
   if (overrideCurrentProvider) {
-    const mainnetProvider = new JsonRpcProvider(RPC[ChainId.MAINNET], 'any')
+    const mainnetProvider = new JsonRpcProvider(RPC[ChainId.MAINNET], ChainId.MAINNET)
     return new Contract(address, ABI, mainnetProvider as any)
   }
   return new Contract(address, ABI, getProviderOrSigner(library, account) as any)

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,12 +1,13 @@
 import { Contract } from '@ethersproject/contracts'
 import { getAddress } from '@ethersproject/address'
 import { AddressZero } from '@ethersproject/constants'
-import { JsonRpcSigner, Web3Provider } from '@ethersproject/providers'
+import { JsonRpcSigner, Web3Provider, JsonRpcProvider } from '@ethersproject/providers'
 import { BigNumber } from '@ethersproject/bignumber'
 import { abi as IUniswapV2Router02ABI } from '@uniswap/v2-periphery/build/IUniswapV2Router02.json'
 import { ChainId, JSBI, Percent, Token, CurrencyAmount, Currency, ETHER, ROUTER_ADDRESS } from '@sushiswap/sdk'
 import { TokenAddressMap } from '../state/lists/hooks'
 import ethers from 'ethers'
+import { RPC } from 'connectors'
 
 import Fraction from '../constants/Fraction'
 
@@ -250,11 +251,20 @@ export function getProviderOrSigner(library: Web3Provider, account?: string): We
 }
 
 // account is optional
-export function getContract(address: string, ABI: any, library: Web3Provider, account?: string): Contract {
+export function getContract(
+  address: string,
+  ABI: any,
+  library: Web3Provider,
+  account?: string,
+  overrideCurrentProvider?: boolean
+): Contract {
   if (!isAddress(address) || address === AddressZero) {
     throw Error(`Invalid 'address' parameter '${address}'.`)
   }
-
+  if (overrideCurrentProvider) {
+    const mainnetProvider = new JsonRpcProvider(RPC[ChainId.MAINNET], 'any')
+    return new Contract(address, ABI, mainnetProvider as any)
+  }
   return new Contract(address, ABI, getProviderOrSigner(library, account) as any)
 }
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
## Description of Changes
Added JSONPRCPrrovider to connect to mainnet for displaying xRNBW:RNBW price in vesting  when user is connected to Polygon.

How to test:
1. Go to vesting page
2. Connect to mainnet (take note of the %APY and xRNBW:RNBW price)
3. Switch network to Polygon (%APY and xRNBW:RNBW price shhould be same as mainnet) 
4. Optionally switch to other networks like Kovan, check the price in Kovan, then switch back to Polygon

[Link to Jira Ticket](https://halodao.atlassian.net/browse/HDEV-241)


### Developer Checklist:

* [x] I have followed the guidelines in our Contributing document
* [x] This PR has a corresponding JIRA ticket
* [] My branch conforms with our naming convention i.e. `feature/HDEV-XXX-description`
* [ ] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [ ] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
