### PR TITLE
Tiny PR: XIDR "fraction exceeds decimal" fix

### DIFF
--- a/src/halo-hooks/amm/useAddRemoveLiquidity.ts
+++ b/src/halo-hooks/amm/useAddRemoveLiquidity.ts
@@ -86,7 +86,7 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
       const quoteNumeraire = quoteAmountVal // no need to convert, quote (USDC) is numeraire
       const multiplier = isDoubleEstimatePool(address, chainId) ? 1 : 2
       const totalNumeraire = quoteNumeraire * multiplier
-      const estimate = await viewDeposit(parseEther(`${totalNumeraire}`))
+      const estimate = await viewDeposit(parseEther(totalNumeraire.toFixed(18)))
 
       let depositPreview = {
         deposit: totalNumeraire,
@@ -119,7 +119,7 @@ export const useAddRemoveLiquidity = (address: string, token0: Token, token1: To
       const baseNumeraire = baseAmountVal * baseRate
       const multiplier = isDoubleEstimatePool(address, chainId) ? 1 : baseWeight > 0 ? 1 / baseWeight : 2
       const totalNumeraire = baseNumeraire * multiplier
-      const estimate = await viewDeposit(parseEther(`${totalNumeraire}`))
+      const estimate = await viewDeposit(parseEther(totalNumeraire.toFixed(18)))
 
       let depositPreview = {
         deposit: totalNumeraire,


### PR DESCRIPTION
Fixes the error below by limiting decimals to 18 places before passing to `parseEther()`:

```
Unhandled Rejection (Error): fractional component exceeds decimals (fault="underflow", operation="parseFixed", code=NUMERIC_FAULT, version=bignumber/5.0.5)
```

### Developer Checklist:

* [x] I have followed the guidelines in our Contributing document
* [ ] This PR has a corresponding JIRA ticket
* [x] My branch conforms with our naming convention i.e. `feature/HDEV-XXX-description`
* [x] All files have appropriate file headers and documentation
* [ ] I have written new tests for your core changes, as applicable
* [ ] I have successfully ran tests locally

### Reviewers Checklist:
* [ ] Code is readable and understandable; any unclear parts have explanations 
* [ ] UI/UX changes match the corresponding figma/other design resources, if applicable
* [ ] I have successfully ran tests locally
